### PR TITLE
drawer fixes

### DIFF
--- a/src/components/Location/LinksDrawer/LinkCard.module.css
+++ b/src/components/Location/LinksDrawer/LinkCard.module.css
@@ -25,7 +25,7 @@
 
 .dinoImg {
   height: 95%;
-  height: 95%;
+  width: 95%;
 }
 
 .nameContainer {

--- a/src/components/Location/LinksDrawer/LinksDrawer.jsx
+++ b/src/components/Location/LinksDrawer/LinksDrawer.jsx
@@ -43,14 +43,14 @@ export default function LinksDrawer({
   };
 
   // to stop body scroll when filter drawer is open - this seems an odd way to do it, does anyone know of a better way?
-  useEffect(() => {
-    if (isLinksDrawerOpen) {
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.body.style.overflow = "scroll";
-    };
-  }, [isLinksDrawerOpen]);
+  // useEffect(() => {
+  //   if (isLinksDrawerOpen) {
+  //     document.body.style.overflowY = "hidden";
+  //   }
+  //   return () => {
+  //     document.body.style.overflow = "scroll";
+  //   };
+  // }, [isLinksDrawerOpen]);
 
   return (
     <div

--- a/src/components/Location/LinksDrawer/LinksDrawer.module.css
+++ b/src/components/Location/LinksDrawer/LinksDrawer.module.css
@@ -21,7 +21,7 @@
   right: -100%;
   height: 100%;
   width: 375px;
-  background-color: #fff;
+  background-color: #fefaf4;
   transition: 2s;
   overflow-y: auto;
   display: flex;

--- a/src/components/filter/drawer/FilterDrawer.jsx
+++ b/src/components/filter/drawer/FilterDrawer.jsx
@@ -27,14 +27,14 @@ export default function FilterDrawer({
     useAccordianData(searchResults);
 
   // to stop body scroll when filter drawer is open - this seems an odd way to do it, does anyone know of a better way?
-  useEffect(() => {
-    if (isFilterDrawerOpen) {
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.body.style.overflow = "scroll";
-    };
-  }, [isFilterDrawerOpen]);
+  // useEffect(() => {
+  //   if (isFilterDrawerOpen) {
+  //     document.body.style.overflow = "hidden";
+  //   }
+  //   return () => {
+  //     document.body.style.overflow = "scroll";
+  //   };
+  // }, [isFilterDrawerOpen]);
 
   // function to close drawer when user clicks on overlay
   const handleCloseOverlay = (e) => {

--- a/src/components/filter/drawer/FilterDrawer.module.css
+++ b/src/components/filter/drawer/FilterDrawer.module.css
@@ -47,13 +47,13 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
-  transition: 1.5s;
+  /* flex-grow: 1;
+  transition: 1.5s; */
 }
 
 .drawerActive {
   right: 0;
-  transition: 1.5s;
+  transition: 0.5s;
 }
 
 .buttonContainer {


### PR DESCRIPTION
- fix pic width for dino cards so it doesnt overflow on landing page drawer
- removed overscroll hidden when drawers open as it was causing a page shift, there is now unfortunately two scrolls-y when drawer is open now though
- matched transition times for drawers on the landing and search page